### PR TITLE
Hotfix for incorrect site metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <meta name="theme-color" content="#000000">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-  <meta name="Description" content="Andrew Paettie, web development expert in Dallas, Texas. Specialties: Java, NodeJS, Javascript, React" />
+  <meta name="Description" content="Andrew Paettie, full-stack web development expert in Oregon. Specialties: Java, Javascript, React, Database design, Network security" />
   <title>Andrew Paettie</title>
 </head>
 <body >


### PR DESCRIPTION
# What
update location from TX -> OR

# Later
may want to just remove this info soon
as it seems employers are caring less about this information thanks to remove work brought on by covid